### PR TITLE
fix version compatibility

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ minecraft_version=1.3.2
 yarn_mappings=1.3.2+build.202204041642
 loader_version=0.13.3
 # Mod Properties
-mod_version=1.1+1.3.x-1.5.x
+mod_version=1.2+1.3.x-1.5.x
 maven_group=com.redlimerl.mcsr
 archives_base_name=StatsPerReset
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -13,6 +13,6 @@
     "statsperworld.mixins.json"
   ],
   "depends": {
-    "minecraft": ">=1.3- <=1.5-"
+    "minecraft": ">=1.3 <=1.5.2"
   }
 }


### PR DESCRIPTION
mod previously crashed on 1.5.2 b/c it did:
```json
  "depends": {
    "minecraft": ">=1.3- <=1.5-"
  }
  ```
which doesn't work.
I tried:
```json
  "depends": {
    "minecraft": ">=~1.3 <=~1.5"
  }
  ```
but apparently that doesn't work either, so i had to hardcode `<=1.5.2` in.